### PR TITLE
Minor Docs improvements & preference uniqueness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2019 Ayogo Health Inc.
+  Copyright 2020 Ayogo Health Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,12 +34,18 @@ Installation
 ------------
 
 ```
-cordova plugin add cordova-plugin-oauth --variable URL_SCHEME=mycoolapp
+cordova plugin add cordova-plugin-oauth [--variable URL_SCHEME=mycoolapp]
 ```
 
-URL_SCHEME will be registered as the scheme to be used as the OAuth callback URL, 
-and expects a host of `oauth_callback` (i.e., if your app's ID is `mycoolapp`, 
-your OAuth redirect URL should be `mycoolapp://oauth_callback`).
+By default, the plugin registers the app ID as a scheme to be used as the
+OAuth callback URL, and expects a host of `oauth_callback` (i.e., if your
+app's ID is `com.example.foo`, your OAuth redirect URL should be
+`com.example.foo://oauth_callback`).
+
+The scheme for the OAuth callback URL can be changed by providing a
+`URL_SCHEME` variable when installing. If your `URL_SCHEME` is `mycoolapp`,
+then your OAuth redirect URL should be `mycoolapp://oauth_callback`.
+
 
 Supported Platforms
 -------------------
@@ -101,6 +107,6 @@ Licence
 -------
 
 Released under the Apache 2.0 Licence.  
-Copyright © 2019 Ayogo Health Inc.
+Copyright © 2020 Ayogo Health Inc.
 
 [coc]: https://github.com/AyogoHealth/cordova-plugin-oauth/blob/master/CODE_OF_CONDUCT.md

--- a/plugin.xml
+++ b/plugin.xml
@@ -34,7 +34,7 @@ limitations under the License.
   </js-module>
 
   <config-file target="config.xml" parent="/*">
-    <preference name="urlScheme" value="$URL_SCHEME"/>
+    <preference name="OAuthScheme" value="$URL_SCHEME"/>
   </config-file>
 
   <platform name="ios">

--- a/src/ios/OAuthPlugin.swift
+++ b/src/ios/OAuthPlugin.swift
@@ -122,7 +122,7 @@ class OAuthPlugin : CDVPlugin, SFSafariViewControllerDelegate, ASWebAuthenticati
     var logger : OSLog?
 
     override func pluginInitialize() {
-        let urlScheme = self.commandDelegate.settings["urlscheme"] as! String
+        let urlScheme = self.commandDelegate.settings["OAuthScheme"] as! String
 
         self.callbackScheme = "\(urlScheme)://oauth_callback"
         self.logger = OSLog(subsystem: urlScheme, category: "Cordova")


### PR DESCRIPTION
* Clarify in the README that the default value is still to use the package name, and that the `URL_SCHEME` variable is available to override that behaviour.

* Use `OAuthScheme` as the preference instead of `urlScheme` due to paranoia about potential conflicts with other plugins.

/fyi @charpour