### PR TITLE
Require cordova-ios 6.1.0 or newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Ayogo Health Inc.
+  Copyright 2021 Ayogo Health Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ then your OAuth redirect URL should be `mycoolapp://oauth_callback`.
 Supported Platforms
 -------------------
 
-* **iOS** (cordova-ios >= 5.0.0)
+* **iOS** (cordova-ios >= 6.1.0)
 * **Android** (cordova-android >= 8.0.0)
 
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "cordova-ios",
-      "version": ">= 5.0.0"
+      "version": ">= 6.1.0"
     }
   ],
   "dependencies": {}

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,7 +25,7 @@ limitations under the License.
   <preference name="URL_SCHEME" default="$PACKAGE_NAME" />
 
   <engines>
-    <engine name="cordova-ios" version=">= 5.0.0" />
+    <engine name="cordova-ios" version=">= 6.1.0" />
     <engine name="cordova-android" version=">= 8.0.0" />
   </engines>
 


### PR DESCRIPTION
Earlier versions don't properly handle defaulting the scheme to the project ID (see https://github.com/apache/cordova-ios/pull/910)

This will be released as a new major version.