### PR TITLE
Add null check on `name` parameter

### DIFF
--- a/www/oauth.js
+++ b/www/oauth.js
@@ -20,7 +20,7 @@ var noop = function() { };
 
 
 module.exports = function(url, name, features) {
-  if (name.match(/^oauth:/)) {
+  if (name && name.match && name.match(/^oauth:/)) {
     cordova.exec(noop, noop, 'OAuth', 'startOAuth', [url]);
   } else {
     var originalWindowOpen = modulemapper.getOriginalSymbol(window, 'open');


### PR DESCRIPTION
Hi,

We're running into a problem where another library calls `window.open` without a `name` argument. This results in a `ReferenceError` in `www/oauth.js` and stops execution. This pull request should correct that problem.

Thank you for your consideration!
Ethan