### PR TITLE
Fix issue with invalid callback scheme

### DIFF
--- a/src/ios/OAuthPlugin.swift
+++ b/src/ios/OAuthPlugin.swift
@@ -32,7 +32,8 @@ class ASWebAuthenticationSessionOAuthSessionProvider : OAuthSessionProvider {
     var delegate : AnyObject?
 
     required init(_ endpoint : URL, callbackScheme : String) {
-        self.aswas = ASWebAuthenticationSession(url: endpoint, callbackURLScheme: callbackScheme, completionHandler: { (callBack:URL?, error:Error?) in
+        let encodedCallback = callbackScheme.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
+        self.aswas = ASWebAuthenticationSession(url: endpoint, callbackURLScheme: encodedCallback, completionHandler: { (callBack:URL?, error:Error?) in
             if let incomingUrl = callBack {
                 NotificationCenter.default.post(name: NSNotification.Name.CDVPluginHandleOpenURL, object: incomingUrl)
             }


### PR DESCRIPTION
This fixes the issue raised in #18 with a minimal change, not resulting in a change to the actual value passed to `callbackURLScheme`.

Would also request that this be cherry-picked into a 2.x release as we are still using that version.

Thank you!