### PR TITLE
Support androidx and fix iOS crash

### DIFF
--- a/src/android/OAuthPlugin.java
+++ b/src/android/OAuthPlugin.java
@@ -23,7 +23,7 @@ import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
-import android.support.customtabs.CustomTabsIntent;
+import androidx.browser.customtabs.CustomTabsIntent;
 import android.text.TextUtils;
 
 import java.util.ArrayList;

--- a/src/ios/OAuthPlugin.swift
+++ b/src/ios/OAuthPlugin.swift
@@ -32,7 +32,9 @@ class ASWebAuthenticationSessionOAuthSessionProvider : OAuthSessionProvider {
     var delegate : AnyObject?
 
     required init(_ endpoint : URL, callbackScheme : String) {
-        self.aswas = ASWebAuthenticationSession(url: endpoint, callbackURLScheme: callbackScheme, completionHandler: { (callBack:URL?, error:Error?) in
+        let url: URL = URL(string: callbackScheme)!
+        let callbackURLScheme: String = url.scheme ?? callbackScheme
+        self.aswas = ASWebAuthenticationSession(url: endpoint, callbackURLScheme: callbackURLScheme, completionHandler: { (callBack:URL?, error:Error?) in
             if let incomingUrl = callBack {
                 NotificationCenter.default.post(name: NSNotification.Name.CDVPluginHandleOpenURL, object: incomingUrl)
             }


### PR DESCRIPTION
Fixes #21 - support androidx.
After merging this I suggest to release a version with an incremented major number i.e 4.x since this is a breaking change.