### PR TITLE
Support AndroidX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2021 Ayogo Health Inc.
+  Copyright 2021-2022 Ayogo Health Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -29,6 +29,10 @@ falling back to their browser.
 
 **Note:** This plugin might conflict with the Cordova In-App Browser plugin!
 
+> ℹ️ **This plugin uses AndroidX!**
+>
+> Use version 3.x if you are building without AndroidX enabled.
+
 
 Installation
 ------------
@@ -51,7 +55,7 @@ Supported Platforms
 -------------------
 
 * **iOS** (cordova-ios >= 6.1.0)
-* **Android** (cordova-android >= 8.0.0)
+* **Android** (cordova-android >= 9.0.0)
 
 
 Usage
@@ -107,6 +111,6 @@ Licence
 -------
 
 Released under the Apache 2.0 Licence.  
-Copyright © 2020 Ayogo Health Inc.
+Copyright © 2020-2022 Ayogo Health Inc.
 
 [coc]: https://github.com/AyogoHealth/cordova-plugin-oauth/blob/main/CODE_OF_CONDUCT.md

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "engines": [
     {
       "name": "cordova-android",
-      "version": ">= 8.0.0"
+      "version": ">= 9.0.0"
     },
     {
       "name": "cordova-ios",

--- a/plugin.xml
+++ b/plugin.xml
@@ -26,7 +26,7 @@ limitations under the License.
 
   <engines>
     <engine name="cordova-ios" version=">= 6.1.0" />
-    <engine name="cordova-android" version=">= 8.0.0" />
+    <engine name="cordova-android" version=">= 9.0.0" />
   </engines>
 
   <js-module src="www/oauth.js" name="OAuth">
@@ -82,8 +82,8 @@ limitations under the License.
 
     <source-file src="src/android/OAuthPlugin.java" target-dir="src/com/ayogo/cordova/oauth" />
 
-    <preference name="ANDROID_SUPPORT_CUSTOM_TABS_VERSION" default="28.+" />
+    <preference name="ANDROID_SUPPORT_CUSTOM_TABS_VERSION" default="1.3.0" />
 
-    <framework src="com.android.support:customtabs:$ANDROID_SUPPORT_CUSTOM_TABS_VERSION" />
+    <framework src="androidx.browser:browser:$ANDROID_SUPPORT_CUSTOM_TABS_VERSION" />
   </platform>
 </plugin>

--- a/src/android/OAuthPlugin.java
+++ b/src/android/OAuthPlugin.java
@@ -23,7 +23,7 @@ import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
-import android.support.customtabs.CustomTabsIntent;
+import androidx.browser.customtabs.CustomTabsIntent;
 import android.text.TextUtils;
 
 import java.util.ArrayList;


### PR DESCRIPTION
Builds on #23 

This should include all the gradle reference stuff, as well as increasing the minimum Cordova Android version to 9.0.0 (which is when the AndroidX preference was first supported).