### PR TITLE
Detect cancellation of login

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Usage
     Universal Links and App Links so that the same flow can be used in both
     mobile apps and web.
 
+    If the login was cancelled by the user without interacting with the 
+    endpoint by closing the overlay without logging in, the received message 
+    in JavaScript will be `oauth::{"error": "cancelled"}`.
+
 
 Contributing
 ------------

--- a/src/android/OAuthPlugin.java
+++ b/src/android/OAuthPlugin.java
@@ -58,7 +58,7 @@ public class OAuthPlugin extends CordovaPlugin {
      * The name of the package to use for the custom tab service.
      */
     private String tabProvider = null;
-
+    private boolean loginSuccessful = false;
 
     /**
      * Executes the request.
@@ -121,6 +121,7 @@ public class OAuthPlugin extends CordovaPlugin {
                 }
 
                 final String msg = jsobj.toString();
+                loginSuccessful = true;
                 this.webView.getEngine().evaluateJavascript("window.dispatchEvent(new MessageEvent('message', { data: 'oauth::" + msg + "' }));", null);
             } catch (JSONException e) {
                 LOG.e(TAG, "JSON Serialization failed");
@@ -129,6 +130,19 @@ public class OAuthPlugin extends CordovaPlugin {
         }
     }
 
+  @Override
+  public void onResume(boolean multitasking) {
+    super.onResume(multitasking);
+    // Chrome Custom Tabs currently have no way to detect that they were closed.
+    // But if this happens, the app resumes and onResume is called which can be used as workaround.
+    // If we didn't handle a successful oAuth response, we can assume that the login was cancelled in onResume.
+    if (!loginSuccessful) {
+      this.webView.getEngine().evaluateJavascript("window.dispatchEvent(new MessageEvent('message', { data: 'oauth::{\"error\":\"cancelled\"}' }));", null);
+    } else {
+      // reset loginSuccessful to make sure it is correctly initialized on the next login attempt
+      loginSuccessful = false;
+    }
+  }
 
     /**
      * Launches the custom tab with the OAuth endpoint URL.

--- a/src/ios/OAuthPlugin.swift
+++ b/src/ios/OAuthPlugin.swift
@@ -37,6 +37,8 @@ class ASWebAuthenticationSessionOAuthSessionProvider : OAuthSessionProvider {
         self.aswas = ASWebAuthenticationSession(url: endpoint, callbackURLScheme: callbackURLScheme, completionHandler: { (callBack:URL?, error:Error?) in
             if let incomingUrl = callBack {
                 NotificationCenter.default.post(name: NSNotification.Name.CDVPluginHandleOpenURL, object: incomingUrl)
+            } else if let err = error {
+                NotificationCenter.default.post(name: Notification.Name("oAuthCancellation"), object: err)
             }
         })
     }
@@ -64,6 +66,8 @@ class SFAuthenticationSessionOAuthSessionProvider : OAuthSessionProvider {
         self.sfas = SFAuthenticationSession(url: endpoint, callbackURLScheme: callbackScheme, completionHandler: { (callBack:URL?, error:Error?) in
             if let incomingUrl = callBack {
                 NotificationCenter.default.post(name: NSNotification.Name.CDVPluginHandleOpenURL, object: incomingUrl)
+            } else if let err = error {
+                NotificationCenter.default.post(name: Notification.Name("oAuthCancellation"), object: err)
             }
         })
     }
@@ -134,6 +138,11 @@ class OAuthPlugin : CDVPlugin, SFSafariViewControllerDelegate, ASWebAuthenticati
         NotificationCenter.default.addObserver(self,
                 selector: #selector(OAuthPlugin._handleOpenURL(_:)),
                 name: NSNotification.Name.CDVPluginHandleOpenURL,
+                object: nil)
+
+        NotificationCenter.default.addObserver(self,
+                selector: #selector(OAuthPlugin._handleError(_:)),
+                name: Notification.Name("oAuthCancellation"),
                 object: nil)
     }
 
@@ -209,6 +218,10 @@ class OAuthPlugin : CDVPlugin, SFSafariViewControllerDelegate, ASWebAuthenticati
         }
     }
 
+
+    @objc internal func _handleError(_ notification : NSNotification) {
+        self.webViewEngine.evaluateJavaScript("window.dispatchEvent(new MessageEvent('message', { data: 'oauth::{\"error\":\"cancelled\"}' }));", completionHandler: nil)
+    }
 
     @objc internal func _handleOpenURL(_ notification : NSNotification) {
         guard let url = notification.object as? URL else {


### PR DESCRIPTION
We had an issue similar to https://github.com/AyogoHealth/cordova-plugin-oauth/issues/20, where we needed to detect when the oAuth progress was cancelled by the user (thus the login overlay closes without getting a redirect from the identity providers endpoint, as the user never interacted with it).
Currently the plugins sends no message at all if this happens, therefore we couldn't detect this case.

We solved it by adding a special message that the plugin sends when this happens: `oauth:{"error":"cancelled"}`.

The only edge case that came up while testing is, that while closing the overlay via the close buttons included in the overlay itself returns the new message (instead of nothing), canceling via the actual dialog will still return the regular response from the identity provider (as before).

While this makes sense implementation wise, it might be a bit confusing when using it.

What do you think? 

Tested without issues on Android 12 and iOS 15. Note that while I'm sufficiently familiar with Android, I don't know much about Swift, and the implementation for iOS was more based on testing and following the documentation for [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/authenticating_a_user_through_a_web_service) than actually understanding what exactly I'm doing (but seems to run just fine).