### PR TITLE
iOS Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test-ios:
+    name: "iOS Tests"
+    runs-on: macos-12
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_13.4.1.app/Contents/Developer
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Set up example app
+        run: |
+          npm i
+          npx cordova prepare ios
+        working-directory: ./example
+
+      - name: Run iOS Unit Tests
+        run: |
+          xcodebuild test -quiet \
+            -project OAuthPluginTests.xcodeproj \
+            -scheme OAuthPluginTests \
+            -testPlan UnitTests \
+            -destination "platform=iOS Simulator,name=iPhone 13"
+        working-directory: ./tests/ios
+
+      - name: Run iOS UI Tests
+        run: |
+          xcodebuild test -quiet \
+            -project OAuthPluginTests.xcodeproj \
+            -scheme OAuthPluginTests \
+            -testPlan DeviceTests \
+            -destination "platform=iOS Simulator,name=iPhone 13"
+        working-directory: ./tests/ios

--- a/src/ios/OAuthPlugin.swift
+++ b/src/ios/OAuthPlugin.swift
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#if canImport(Cordova)
+import Cordova
+#endif
+
 import os.log
 import Foundation
 import AuthenticationServices

--- a/src/ios/OAuthPlugin.swift
+++ b/src/ios/OAuthPlugin.swift
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Ayogo Health Inc.
+ * Copyright 2019 - 2022 Ayogo Health Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,6 +123,9 @@ class SafariAppOAuthSessionProvider : OAuthSessionProvider {
 
 @objc(CDVOAuthPlugin)
 class OAuthPlugin : CDVPlugin, SFSafariViewControllerDelegate, ASWebAuthenticationPresentationContextProviding {
+    /** This exists for testing purposes */
+    static var forcedVersion : UInt32 = UInt32.max
+
     var authSystem : OAuthSessionProvider?
     var callbackScheme : String?
     var logger : OSLog?
@@ -153,7 +156,7 @@ class OAuthPlugin : CDVPlugin, SFSafariViewControllerDelegate, ASWebAuthenticati
             return
         }
 
-        if #available(iOS 12.0, *) {
+        if OAuthPlugin.forcedVersion >= 12, #available(iOS 12.0, *) {
             self.authSystem = ASWebAuthenticationSessionOAuthSessionProvider(url, callbackScheme:self.callbackScheme!)
 
             if #available(iOS 13.0, *) {
@@ -161,9 +164,9 @@ class OAuthPlugin : CDVPlugin, SFSafariViewControllerDelegate, ASWebAuthenticati
                     aswas.delegate = self
                 }
             }
-        } else if #available(iOS 11.0, *) {
+        } else if OAuthPlugin.forcedVersion >= 11, #available(iOS 11.0, *) {
             self.authSystem = SFAuthenticationSessionOAuthSessionProvider(url, callbackScheme:self.callbackScheme!)
-        } else if #available(iOS 9.0, *) {
+        } else if OAuthPlugin.forcedVersion >= 9, #available(iOS 9.0, *) {
             self.authSystem = SFSafariViewControllerOAuthSessionProvider(url, callbackScheme:self.callbackScheme!)
 
             if let sfvc = self.authSystem as? SFSafariViewControllerOAuthSessionProvider {

--- a/tests/ios/.gitignore
+++ b/tests/ios/.gitignore
@@ -1,0 +1,3 @@
+xcuserdata/
+Package.resolved
+App/www

--- a/tests/ios/App/AppDelegate.swift
+++ b/tests/ios/App/AppDelegate.swift
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2022 Ayogo Health Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import UIKit
+import Cordova
+
+@UIApplicationMain
+class AppDelegate: CDVAppDelegate {
+}

--- a/tests/ios/App/config.xml
+++ b/tests/ios/App/config.xml
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+Copyright 2022 Ayogo Health Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<widget id="com.ayogo.cordova.oauth.tests" version="1.0.0" xmlns="http://www.w3.org/ns/widgets">
+    <name>OAuthPluginTests</name>
+    <author email="info@ayogo.com" href="http://www.ayogo.com">Ayogo Health Inc.</author>
+
+    <content src="index.html" />
+
+    <allow-intent href="http://*/*" />
+    <allow-intent href="https://*/*" />
+
+    <preference name="AllowInlineMediaPlayback" value="false" />
+    <preference name="BackupWebStorage" value="cloud" />
+    <preference name="DisallowOverscroll" value="true" />
+    <preference name="EnableViewportScale" value="false" />
+    <preference name="KeyboardDisplayRequiresUserAction" value="true" />
+    <preference name="MediaTypesRequiringUserActionForPlayback" value="none" />
+    <preference name="SuppressesIncrementalRendering" value="false" />
+    <preference name="SuppressesLongPressGesture" value="false" />
+    <preference name="Suppresses3DTouchGesture" value="false" />
+    <preference name="GapBetweenPages" value="0" />
+    <preference name="PageLength" value="0" />
+    <preference name="PaginationBreakingMode" value="page" />
+    <preference name="PaginationMode" value="unpaginated" />
+    <preference name="OAuthScheme" value="oauthtest" />
+    <preference name="SwiftVersion" value="5.0" />
+
+    <feature name="CDVWebViewEngine">
+        <param name="ios-package" value="CDVWebViewEngine" />
+    </feature>
+    <feature name="LaunchScreen">
+        <param name="ios-package" value="CDVLaunchScreen" />
+    </feature>
+    <feature name="LocalStorage">
+        <param name="ios-package" value="CDVLocalStorage" />
+    </feature>
+    <feature name="Console">
+        <param name="ios-package" value="CDVLogger" />
+        <param name="onload" value="true" />
+    </feature>
+    <feature name="HandleOpenUrl">
+        <param name="ios-package" value="CDVHandleOpenURL" />
+        <param name="onload" value="true" />
+    </feature>
+    <feature name="IntentAndNavigationFilter">
+        <param name="ios-package" value="CDVIntentAndNavigationFilter" />
+        <param name="onload" value="true" />
+    </feature>
+    <feature name="GestureHandler">
+        <param name="ios-package" value="CDVGestureHandler" />
+        <param name="onload" value="true" />
+    </feature>
+    <feature name="OAuth">
+        <param name="ios-package" value="CDVOAuthPlugin" />
+        <param name="onload" value="true" />
+    </feature>
+</widget>

--- a/tests/ios/OAuthPluginTests.xcodeproj/DeviceTests.xctestplan
+++ b/tests/ios/OAuthPluginTests.xcodeproj/DeviceTests.xctestplan
@@ -1,0 +1,29 @@
+{
+  "configurations" : [
+    {
+      "id" : "499B7A65-D2B7-4953-8541-6A9A89F54ADE",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:OAuthPluginTests.xcodeproj",
+      "identifier" : "905131B827F1631300AC00FC",
+      "name" : "OAuthPluginTest"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:OAuthPluginTests.xcodeproj",
+        "identifier" : "905131D827F1631600AC00FC",
+        "name" : "UITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/tests/ios/OAuthPluginTests.xcodeproj/UnitTests.xctestplan
+++ b/tests/ios/OAuthPluginTests.xcodeproj/UnitTests.xctestplan
@@ -1,0 +1,30 @@
+{
+  "configurations" : [
+    {
+      "id" : "AE69ADA5-1D54-4DAE-AD6A-E00C0A1C9CD0",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : true,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:OAuthPluginTests.xcodeproj",
+      "identifier" : "905131B827F1631300AC00FC",
+      "name" : "OAuthPluginTest"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:OAuthPluginTests.xcodeproj",
+        "identifier" : "905131CE27F1631600AC00FC",
+        "name" : "Tests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/tests/ios/OAuthPluginTests.xcodeproj/project.pbxproj
+++ b/tests/ios/OAuthPluginTests.xcodeproj/project.pbxproj
@@ -1,0 +1,597 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 53;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		905131BD27F1631300AC00FC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905131BC27F1631300AC00FC /* AppDelegate.swift */; };
+		905131D427F1631600AC00FC /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905131D327F1631600AC00FC /* Tests.swift */; };
+		905131DE27F1631600AC00FC /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905131DD27F1631600AC00FC /* UITests.swift */; };
+		905131EE27F1648A00AC00FC /* CordovaLib in Frameworks */ = {isa = PBXBuildFile; productRef = 905131ED27F1648A00AC00FC /* CordovaLib */; };
+		905131F127F1670900AC00FC /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 905131F027F1670900AC00FC /* config.xml */; };
+		905131F827F168FC00AC00FC /* OAuthPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905131F727F168FC00AC00FC /* OAuthPlugin.swift */; };
+		907328F328D04C0C006F6BFA /* www in Resources */ = {isa = PBXBuildFile; fileRef = 907328F228D04C0C006F6BFA /* www */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		905131D027F1631600AC00FC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 905131B127F1631300AC00FC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 905131B827F1631300AC00FC;
+			remoteInfo = Tests;
+		};
+		905131DA27F1631600AC00FC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 905131B127F1631300AC00FC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 905131B827F1631300AC00FC;
+			remoteInfo = Tests;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		905131B927F1631300AC00FC /* OAuthPluginTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OAuthPluginTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		905131BC27F1631300AC00FC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		905131CF27F1631600AC00FC /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		905131D327F1631600AC00FC /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
+		905131D927F1631600AC00FC /* UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		905131DD27F1631600AC00FC /* UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests.swift; sourceTree = "<group>"; };
+		905131F027F1670900AC00FC /* config.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = config.xml; sourceTree = "<group>"; };
+		905131F727F168FC00AC00FC /* OAuthPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OAuthPlugin.swift; path = ../../../src/ios/OAuthPlugin.swift; sourceTree = "<group>"; };
+		9056A938285BDDC00086CDF8 /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UnitTests.xctestplan; path = OAuthPluginTests.xcodeproj/UnitTests.xctestplan; sourceTree = "<group>"; };
+		9056A939285BDE4E0086CDF8 /* DeviceTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = DeviceTests.xctestplan; path = OAuthPluginTests.xcodeproj/DeviceTests.xctestplan; sourceTree = "<group>"; };
+		907328F228D04C0C006F6BFA /* www */ = {isa = PBXFileReference; lastKnownFileType = folder; name = www; path = ../../../example/platforms/ios/www; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		905131B627F1631300AC00FC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				905131EE27F1648A00AC00FC /* CordovaLib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		905131CC27F1631600AC00FC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		905131D627F1631600AC00FC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		905131B027F1631300AC00FC = {
+			isa = PBXGroup;
+			children = (
+				9056A939285BDE4E0086CDF8 /* DeviceTests.xctestplan */,
+				9056A938285BDDC00086CDF8 /* UnitTests.xctestplan */,
+				905131BB27F1631300AC00FC /* App */,
+				905131D227F1631600AC00FC /* Tests */,
+				905131DC27F1631600AC00FC /* UITests */,
+				905131BA27F1631300AC00FC /* Products */,
+				909D55A627F176880050F168 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		905131BA27F1631300AC00FC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				905131B927F1631300AC00FC /* OAuthPluginTest.app */,
+				905131CF27F1631600AC00FC /* Tests.xctest */,
+				905131D927F1631600AC00FC /* UITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		905131BB27F1631300AC00FC /* App */ = {
+			isa = PBXGroup;
+			children = (
+				907328F228D04C0C006F6BFA /* www */,
+				905131F727F168FC00AC00FC /* OAuthPlugin.swift */,
+				905131F027F1670900AC00FC /* config.xml */,
+				905131BC27F1631300AC00FC /* AppDelegate.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		905131D227F1631600AC00FC /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				905131D327F1631600AC00FC /* Tests.swift */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		905131DC27F1631600AC00FC /* UITests */ = {
+			isa = PBXGroup;
+			children = (
+				905131DD27F1631600AC00FC /* UITests.swift */,
+			);
+			path = UITests;
+			sourceTree = "<group>";
+		};
+		909D55A627F176880050F168 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		905131B827F1631300AC00FC /* OAuthPluginTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 905131E327F1631600AC00FC /* Build configuration list for PBXNativeTarget "OAuthPluginTest" */;
+			buildPhases = (
+				905131B527F1631300AC00FC /* Sources */,
+				905131B627F1631300AC00FC /* Frameworks */,
+				905131B727F1631300AC00FC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OAuthPluginTest;
+			packageProductDependencies = (
+				905131ED27F1648A00AC00FC /* CordovaLib */,
+			);
+			productName = Tests;
+			productReference = 905131B927F1631300AC00FC /* OAuthPluginTest.app */;
+			productType = "com.apple.product-type.application";
+		};
+		905131CE27F1631600AC00FC /* Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 905131E627F1631600AC00FC /* Build configuration list for PBXNativeTarget "Tests" */;
+			buildPhases = (
+				905131CB27F1631600AC00FC /* Sources */,
+				905131CC27F1631600AC00FC /* Frameworks */,
+				905131CD27F1631600AC00FC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				905131D127F1631600AC00FC /* PBXTargetDependency */,
+			);
+			name = Tests;
+			packageProductDependencies = (
+			);
+			productName = TestsTests;
+			productReference = 905131CF27F1631600AC00FC /* Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		905131D827F1631600AC00FC /* UITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 905131E927F1631600AC00FC /* Build configuration list for PBXNativeTarget "UITests" */;
+			buildPhases = (
+				905131D527F1631600AC00FC /* Sources */,
+				905131D627F1631600AC00FC /* Frameworks */,
+				905131D727F1631600AC00FC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				905131DB27F1631600AC00FC /* PBXTargetDependency */,
+			);
+			name = UITests;
+			productName = TestsUITests;
+			productReference = 905131D927F1631600AC00FC /* UITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		905131B127F1631300AC00FC /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1330;
+				LastUpgradeCheck = 1330;
+				TargetAttributes = {
+					905131B827F1631300AC00FC = {
+						CreatedOnToolsVersion = 13.3;
+					};
+					905131CE27F1631600AC00FC = {
+						CreatedOnToolsVersion = 13.3;
+						TestTargetID = 905131B827F1631300AC00FC;
+					};
+					905131D827F1631600AC00FC = {
+						CreatedOnToolsVersion = 13.3;
+						TestTargetID = 905131B827F1631300AC00FC;
+					};
+				};
+			};
+			buildConfigurationList = 905131B427F1631300AC00FC /* Build configuration list for PBXProject "OAuthPluginTests" */;
+			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 905131B027F1631300AC00FC;
+			packageReferences = (
+				905131EC27F1648A00AC00FC /* XCRemoteSwiftPackageReference "cordova-ios" */,
+			);
+			productRefGroup = 905131BA27F1631300AC00FC /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				905131B827F1631300AC00FC /* OAuthPluginTest */,
+				905131CE27F1631600AC00FC /* Tests */,
+				905131D827F1631600AC00FC /* UITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		905131B727F1631300AC00FC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				907328F328D04C0C006F6BFA /* www in Resources */,
+				905131F127F1670900AC00FC /* config.xml in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		905131CD27F1631600AC00FC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		905131D727F1631600AC00FC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		905131B527F1631300AC00FC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				905131F827F168FC00AC00FC /* OAuthPlugin.swift in Sources */,
+				905131BD27F1631300AC00FC /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		905131CB27F1631600AC00FC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				905131D427F1631600AC00FC /* Tests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		905131D527F1631600AC00FC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				905131DE27F1631600AC00FC /* UITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		905131D127F1631600AC00FC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 905131B827F1631300AC00FC /* OAuthPluginTest */;
+			targetProxy = 905131D027F1631600AC00FC /* PBXContainerItemProxy */;
+		};
+		905131DB27F1631600AC00FC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 905131B827F1631300AC00FC /* OAuthPluginTest */;
+			targetProxy = 905131DA27F1631600AC00FC /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		905131E127F1631600AC00FC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		905131E227F1631600AC00FC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		905131E427F1631600AC00FC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Tests/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ayogo.cordova.oauth.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		905131E527F1631600AC00FC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Tests/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ayogo.cordova.oauth.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		905131E727F1631600AC00FC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ayogo.cordova.oauth.tests.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OAuthPluginTest.app/OAuthPluginTest";
+			};
+			name = Debug;
+		};
+		905131E827F1631600AC00FC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ayogo.cordova.oauth.tests.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OAuthPluginTest.app/OAuthPluginTest";
+			};
+			name = Release;
+		};
+		905131EA27F1631600AC00FC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"$(LD_RUNPATH_SEARCH_PATHS_SHALLOW_BUNDLE_$(SHALLOW_BUNDLE))",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ayogo.cordova.oauth.tests.UITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = OAuthPluginTest;
+			};
+			name = Debug;
+		};
+		905131EB27F1631600AC00FC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"$(LD_RUNPATH_SEARCH_PATHS_SHALLOW_BUNDLE_$(SHALLOW_BUNDLE))",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ayogo.cordova.oauth.tests.UITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = OAuthPluginTest;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		905131B427F1631300AC00FC /* Build configuration list for PBXProject "OAuthPluginTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				905131E127F1631600AC00FC /* Debug */,
+				905131E227F1631600AC00FC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		905131E327F1631600AC00FC /* Build configuration list for PBXNativeTarget "OAuthPluginTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				905131E427F1631600AC00FC /* Debug */,
+				905131E527F1631600AC00FC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		905131E627F1631600AC00FC /* Build configuration list for PBXNativeTarget "Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				905131E727F1631600AC00FC /* Debug */,
+				905131E827F1631600AC00FC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		905131E927F1631600AC00FC /* Build configuration list for PBXNativeTarget "UITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				905131EA27F1631600AC00FC /* Debug */,
+				905131EB27F1631600AC00FC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		905131EC27F1648A00AC00FC /* XCRemoteSwiftPackageReference "cordova-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apache/cordova-ios.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		905131ED27F1648A00AC00FC /* CordovaLib */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 905131EC27F1648A00AC00FC /* XCRemoteSwiftPackageReference "cordova-ios" */;
+			productName = CordovaLib;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 905131B127F1631300AC00FC /* Project object */;
+}

--- a/tests/ios/OAuthPluginTests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/tests/ios/OAuthPluginTests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/tests/ios/OAuthPluginTests.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/tests/ios/OAuthPluginTests.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/ios/OAuthPluginTests.xcodeproj/xcshareddata/xcschemes/OAuthPluginTests.xcscheme
+++ b/tests/ios/OAuthPluginTests.xcodeproj/xcshareddata/xcschemes/OAuthPluginTests.xcscheme
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1330"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "905131B827F1631300AC00FC"
+               BuildableName = "OAuthPluginTest.app"
+               BlueprintName = "OAuthPluginTest"
+               ReferencedContainer = "container:OAuthPluginTests.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:OAuthPluginTests.xcodeproj/UnitTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:OAuthPluginTests.xcodeproj/DeviceTests.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "905131CE27F1631600AC00FC"
+               BuildableName = "Tests.xctest"
+               BlueprintName = "Tests"
+               ReferencedContainer = "container:OAuthPluginTests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "905131D827F1631600AC00FC"
+               BuildableName = "UITests.xctest"
+               BlueprintName = "UITests"
+               ReferencedContainer = "container:OAuthPluginTests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "905131B827F1631300AC00FC"
+            BuildableName = "OAuthPluginTest.app"
+            BlueprintName = "OAuthPluginTest"
+            ReferencedContainer = "container:OAuthPluginTests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "905131B827F1631300AC00FC"
+            BuildableName = "OAuthPluginTest.app"
+            BlueprintName = "OAuthPluginTest"
+            ReferencedContainer = "container:OAuthPluginTests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/tests/ios/Tests/Info.plist
+++ b/tests/ios/Tests/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>oauthtest</string>
+			</array>
+		</dict>
+	</array>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UIImageName</key>
+		<string></string>
+	</dict>
+</dict>
+</plist>

--- a/tests/ios/Tests/Tests.swift
+++ b/tests/ios/Tests/Tests.swift
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2022 Ayogo Health Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import XCTest
+@testable import Cordova
+@testable import OAuthPluginTest
+
+// MARK: Mock classes
+class MockCommandDelegate : NSObject, CDVCommandDelegate {
+    var settings: [AnyHashable : Any]! {
+        get {
+            return ["oauthscheme": "oauthtest"]
+        }
+    }
+
+    var urlTransformer: UrlTransformerBlock!
+    var lastResult: CDVPluginResult!
+
+    func path(forResource resourcepath: String!) -> String! {
+        return "";
+    }
+
+    func getCommandInstance(_ pluginName: String!) -> Any! {
+        return nil;
+    }
+
+    func send(_ result: CDVPluginResult!, callbackId: String!) {
+        self.lastResult = result
+    }
+
+    func evalJs(_ js: String!) { }
+    func evalJs(_ js: String!, scheduledOnRunLoop: Bool) { }
+    func run(inBackground block: (() -> Void)!) { }
+}
+
+class MockWebViewEngine : NSObject, CDVWebViewEngineProtocol {
+    var engineWebView: UIView
+
+    func evaluateJavaScript(_ javaScriptString: String, completionHandler: ((Any, Error) -> Void)? = nil) {
+        // TODO
+    }
+
+    func url() -> URL {
+        return URL(string: "https://example.com")!
+    }
+
+    func canLoad(_ request: URLRequest) -> Bool {
+        return false
+    }
+
+    required init?(frame: CGRect) {
+        self.engineWebView = WKWebView()
+    }
+    required init?(frame: CGRect, configuration: WKWebViewConfiguration?) {
+        self.engineWebView = WKWebView()
+    }
+    func update(withInfo info: [AnyHashable : Any]) { }
+    func load(_ request: URLRequest) -> Any { return 0 }
+    func loadHTMLString(_ string: String, baseURL: URL?) -> Any { return 0 }
+}
+
+// MARK: Test Cases
+class OAuthPluginTests: XCTestCase {
+    var plugin: OAuthPlugin!
+    var cmdDlg: MockCommandDelegate!
+    var webEngine: MockWebViewEngine!
+    var vc: UIViewController!
+
+    override func setUpWithError() throws {
+        // Always reset this to the default
+        OAuthPlugin.forcedVersion = UInt32.max
+
+        vc = UIViewController()
+        cmdDlg = MockCommandDelegate()
+        webEngine = MockWebViewEngine(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+
+        plugin = OAuthPlugin()
+        plugin.commandDelegate = cmdDlg
+        plugin.viewController = vc
+        plugin.setValue(webEngine, forKey:"webViewEngine")
+    }
+
+    override func tearDownWithError() throws {
+        cmdDlg = nil
+        plugin = nil
+        webEngine = nil
+        vc = nil
+    }
+
+    func testCallbackScheme() throws {
+        plugin.pluginInitialize()
+
+        XCTAssertEqual(plugin.callbackScheme, "oauthtest://oauth_callback", "OAuth Callback Scheme did not match")
+    }
+
+    func testOAuthCommandArgument() throws {
+        plugin.pluginInitialize()
+
+        let emptycmd = CDVInvokedUrlCommand(arguments:[], callbackId:"", className:"CDVOAuthPlugin", methodName:"startOAuth")
+        plugin.startOAuth(emptycmd!)
+        XCTAssertEqual(cmdDlg.lastResult.status as! UInt, CDVCommandStatus.error.rawValue)
+    }
+
+    func testOAuthCommandURL() throws {
+        plugin.pluginInitialize()
+
+        let nonURLcmd = CDVInvokedUrlCommand(arguments:["Hello world!"], callbackId:"", className:"CDVOAuthPlugin", methodName:"startOAuth")
+        plugin.startOAuth(nonURLcmd!)
+        XCTAssertEqual(cmdDlg.lastResult.status as! UInt, CDVCommandStatus.error.rawValue)
+    }
+
+    func testSafariProvider() throws {
+        OAuthPlugin.forcedVersion = 7
+        plugin.pluginInitialize()
+
+        let cmd = CDVInvokedUrlCommand(arguments:["https://example.com"], callbackId:"", className:"CDVOAuthPlugin", methodName:"startOAuth")
+        plugin.startOAuth(cmd!)
+
+        XCTAssertEqual(cmdDlg.lastResult.status as! UInt, CDVCommandStatus.ok.rawValue)
+        XCTAssertTrue(plugin.authSystem is SafariAppOAuthSessionProvider)
+    }
+
+    func testSafariViewControllerProvider() throws {
+        guard #available(iOS 9.0, *) else {
+            throw XCTSkip("Only for iOS 9+")
+        }
+
+        OAuthPlugin.forcedVersion = 9
+        plugin.pluginInitialize()
+
+        let cmd = CDVInvokedUrlCommand(arguments:["https://example.com"], callbackId:"", className:"CDVOAuthPlugin", methodName:"startOAuth")
+        plugin.startOAuth(cmd!)
+
+        XCTAssertEqual(cmdDlg.lastResult.status as! UInt, CDVCommandStatus.ok.rawValue)
+        XCTAssertTrue(plugin.authSystem is SFSafariViewControllerOAuthSessionProvider)
+    }
+
+    func testSFAuthenticationSessionProvider() throws {
+        guard #available(iOS 11.0, *) else {
+            throw XCTSkip("Only for iOS 11+")
+        }
+
+        OAuthPlugin.forcedVersion = 11
+        plugin.pluginInitialize()
+
+        let cmd = CDVInvokedUrlCommand(arguments:["https://example.com"], callbackId:"", className:"CDVOAuthPlugin", methodName:"startOAuth")
+        plugin.startOAuth(cmd!)
+
+        XCTAssertEqual(cmdDlg.lastResult.status as! UInt, CDVCommandStatus.ok.rawValue)
+        XCTAssertTrue(plugin.authSystem is SFAuthenticationSessionOAuthSessionProvider)
+    }
+
+    func testASWebAuthenticationSessionProvider() throws {
+        guard #available(iOS 12.0, *) else {
+            throw XCTSkip("Only for iOS 12+")
+        }
+
+        OAuthPlugin.forcedVersion = 12
+        plugin.pluginInitialize()
+
+        let cmd = CDVInvokedUrlCommand(arguments:["https://example.com"], callbackId:"", className:"CDVOAuthPlugin", methodName:"startOAuth")
+        plugin.startOAuth(cmd!)
+
+        XCTAssertEqual(cmdDlg.lastResult.status as! UInt, CDVCommandStatus.ok.rawValue)
+        XCTAssertTrue(plugin.authSystem is ASWebAuthenticationSessionOAuthSessionProvider)
+    }
+}

--- a/tests/ios/UITests/UITests.swift
+++ b/tests/ios/UITests/UITests.swift
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2022 Ayogo Health Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+
+class OAuthPluginUITests: XCTestCase {
+    let app = XCUIApplication()
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    override func tearDownWithError() throws {
+        let logoutBtn = app.webViews.buttons["Logout"]
+        if logoutBtn.exists {
+            logoutBtn.tap()
+            sleep(1)
+        }
+
+        app.terminate()
+    }
+
+    func testOAuthFlow() throws {
+        app.launch()
+        app.tap()
+
+        // Wait for the landing page to load
+        let landingPage = app.staticTexts["WELCOME!"]
+        _ = landingPage.waitForExistence(timeout: 5)
+
+        // Tap the button, Kronk!
+        let button = app.webViews.buttons["Sign in with OAuth"]
+        XCTAssert(button.exists)
+        XCTAssert(button.isHittable)
+        button.tap()
+
+        if #available(iOS 12.0, *) {
+            runAuthenticationSessionFlow()
+        } else if #available(iOS 11.0, *) {
+            runAuthenticationSessionFlow()
+        } else if #available(iOS 9.0, *) {
+            runSafariViewControllerFlow()
+        } else {
+            runMobileSafariFlow()
+        }
+
+        // Verify the app received the OAuth token and considers us logged in
+        let loggedIn = app.staticTexts["LOGGED IN"]
+        _ = loggedIn.waitForExistence(timeout: 5)
+        XCTAssert(loggedIn.exists)
+    }
+
+    private func runAuthenticationSessionFlow() {
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let continueBtn = springboard.buttons["Continue"]
+        if continueBtn.waitForExistence(timeout: 10) {
+            continueBtn.tap()
+        }
+
+        let oauthButton = app.webViews.buttons["Click Here to Login"]
+        _ = oauthButton.waitForExistence(timeout: 5)
+        XCTAssert(oauthButton.exists)
+        XCTAssert(oauthButton.isHittable)
+        oauthButton.tap()
+    }
+
+    private func runSafariViewControllerFlow() {
+        let oauthButton = app.webViews.buttons["Click Here to Login"]
+        _ = oauthButton.waitForExistence(timeout: 5)
+        XCTAssert(oauthButton.exists)
+        XCTAssert(oauthButton.isHittable)
+        oauthButton.tap()
+    }
+
+    private func runMobileSafariFlow() {
+        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+        _ = safari.wait(for: .runningForeground, timeout: 5)
+
+        let oauthButton = safari.webViews.buttons["Click Here to Login"]
+        _ = oauthButton.waitForExistence(timeout: 5)
+        XCTAssert(oauthButton.exists)
+        XCTAssert(oauthButton.isHittable)
+        oauthButton.tap()
+
+        // Tell Safari to open the app
+        let openBtn = safari.buttons["Open"]
+        if openBtn.waitForExistence(timeout: 5) {
+            openBtn.tap()
+        }
+    }
+}


### PR DESCRIPTION
This uses the example app (added in #24) to run some iOS unit tests and integration tests. Right now, only testing on iPhone 13, but the hope is to eventually get these running on a bunch of real devices covering a range of iOS versions (maybe on AWS Device Farm?)

In any case, the tests will run on every PR which will help provide some safety when making changes. Right now it's hard to feel comfortable accepting anything because it's not easy to test all the edge cases.