### PR TITLE
Cancel detection support & other bugfixes

### DIFF
--- a/example/.postinstall.js
+++ b/example/.postinstall.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2024 Darryl Pogue
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('node:fs');
+
+fs.cpSync('../www/', 'node_modules/cordova-plugin-oauth/www/', { recursive: true, force: true });
+fs.cpSync('../src/', 'node_modules/cordova-plugin-oauth/src/', { recursive: true, force: true });
+fs.cpSync('../plugin.xml', 'node_modules/cordova-plugin-oauth/plugin.xml', { force: true });

--- a/example/package.json
+++ b/example/package.json
@@ -23,6 +23,7 @@
     "cordova-plugin-oauth": ">= 4.0.0"
   },
   "scripts": {
-    "build": "cordova prepare && cordova build --debug --emulator"
+    "build": "cordova prepare && cordova build --debug --emulator",
+    "postinstall": "node .postinstall.js"
   }
 }

--- a/example/www/index.html
+++ b/example/www/index.html
@@ -33,6 +33,12 @@ limitations under the License.
               <button id="login-button" class="login">Sign in with OAuth</button>
           </div>
 
+          <div class="app" slot="login_cancelled">
+              <h1>Login Cancelled!</h1>
+
+              <button id="login-button" class="login">Sign in with OAuth</button>
+          </div>
+
           <div class="app" slot="authenticated">
               <h1>Logged In</h1>
 

--- a/example/www/js/index.js
+++ b/example/www/js/index.js
@@ -21,12 +21,23 @@ const authElements = new Set();
 /**
  * Click handler for the login button to start the OAuth flow.
  */
-document.getElementById('login-button').addEventListener('click', () => {
-  // Our fake OAuth redirecting page
-  const url = 'https://ayogohealth.github.io/cordova-plugin-oauth/example/oauth_access_token.html';
+document.querySelectorAll('.login').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    // Our fake OAuth redirecting page
+    const url = 'https://ayogohealth.github.io/cordova-plugin-oauth/example/oauth_access_token.html';
 
-  // Open a window with the "oauth:" prefix to trigger the plugin
-  window.open(url, 'oauth:testpage');
+    // Open a window with the "oauth:" prefix to trigger the plugin
+    const hwnd = window.open(url, 'oauth:testpage');
+
+    hwnd.addEventListener('close', (evt) => {
+      if (!localStorage.getItem('access_token')) {
+        localStorage.setItem('login_cancelled', 'true');
+
+        // Re-evaluate the authentication elements
+        authElements.forEach((el) => el.evaluateState());
+      }
+    });
+  })
 });
 
 
@@ -80,9 +91,12 @@ class AuthRouterElement extends HTMLElement {
 
   evaluateState() {
     const access_token = localStorage.getItem('access_token');
+    const login_cancelled = localStorage.getItem('login_cancelled');
 
     if (access_token && access_token != '') {
       this.shadowRoot.innerHTML = '<slot name="authenticated"></slot>';
+    } else if (login_cancelled && login_cancelled != '') {
+      this.shadowRoot.innerHTML = '<slot name="login_cancelled"></slot>';
     } else {
       this.shadowRoot.innerHTML = '<slot name="unauthenticated"></slot>';
     }

--- a/tests/android/src/androidTest/java/com/ayogo/cordova/oauth/OAuthPluginTest.java
+++ b/tests/android/src/androidTest/java/com/ayogo/cordova/oauth/OAuthPluginTest.java
@@ -31,6 +31,7 @@ import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiObject2;
 import androidx.test.uiautomator.Until;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -60,6 +61,16 @@ public class OAuthPluginTest {
         device.wait(Until.hasObject(By.pkg(TEST_PACKAGE).depth(0)), TIMEOUT);
     }
 
+    @After
+    public void ensureLogout() {
+        UiObject2 logoutBtn = device.wait(Until.findObject(By.text("Logout")), TIMEOUT);
+        if (logoutBtn != null) {
+            logoutBtn.click();
+
+            device.waitForIdle();
+        }
+    }
+
     @Test
     public void testOAuthFlow() {
         assertNotNull(device);
@@ -79,6 +90,28 @@ public class OAuthPluginTest {
         device.wait(Until.findObject(By.clazz(WebView.class)), TIMEOUT);
 
         device.wait(Until.findObject(By.text("LOGGED IN")), TIMEOUT);
+    }
+
+    @Test
+    public void testOAuthCancellation() {
+        assertNotNull(device);
+
+        device.wait(Until.findObject(By.clazz(WebView.class)), TIMEOUT);
+
+        UiObject2 loginBtn = device.wait(Until.findObject(By.text("Sign in with OAuth")), TIMEOUT);
+        assertNotNull(loginBtn);
+        loginBtn.click();
+
+        // Now we have to close the Chrome Custom Tab without logging in
+        UiObject2 oauthBtn = device.wait(Until.findObject(By.text("Click Here to Login")), TIMEOUT);
+        assertNotNull(oauthBtn);
+
+        device.pressBack();
+
+        // Should be back in the app now
+        device.wait(Until.findObject(By.clazz(WebView.class)), TIMEOUT);
+
+        device.wait(Until.findObject(By.text("LOGIN CANCELLED!")), TIMEOUT);
     }
 
     /**

--- a/tests/ios/Tests/Tests.swift
+++ b/tests/ios/Tests/Tests.swift
@@ -16,35 +16,35 @@
 
 
 import XCTest
+import WebKit
 @testable import Cordova
 @testable import OAuthPluginTest
 
 // MARK: Mock classes
 class MockCommandDelegate : NSObject, CDVCommandDelegate {
-    var settings: [AnyHashable : Any]! {
+    var settings: CDVSettingsDictionary {
         get {
             return ["oauthscheme": "oauthtest"]
         }
     }
 
-    var urlTransformer: UrlTransformerBlock!
     var lastResult: CDVPluginResult!
 
-    func path(forResource resourcepath: String!) -> String! {
+    func path(forResource resourcepath: String) -> String {
         return "";
     }
 
-    func getCommandInstance(_ pluginName: String!) -> Any! {
+    func getCommandInstance(_ pluginName: String) -> CDVPlugin? {
         return nil;
     }
 
-    func send(_ result: CDVPluginResult!, callbackId: String!) {
+    func send(_ result: CDVPluginResult, callbackId: String) {
         self.lastResult = result
     }
 
-    func evalJs(_ js: String!) { }
-    func evalJs(_ js: String!, scheduledOnRunLoop: Bool) { }
-    func run(inBackground block: (() -> Void)!) { }
+    func evalJs(_ js: String) { }
+    func evalJs(_ js: String, scheduledOnRunLoop: Bool) { }
+    func run(inBackground block: (() -> Void)) { }
 }
 
 class MockWebViewEngine : NSObject, CDVWebViewEngineProtocol {
@@ -130,7 +130,6 @@ class OAuthPluginTests: XCTestCase {
         let cmd = CDVInvokedUrlCommand(arguments:["https://example.com"], callbackId:"", className:"CDVOAuthPlugin", methodName:"startOAuth")
         plugin.startOAuth(cmd!)
 
-        XCTAssertEqual(cmdDlg.lastResult.status as! UInt, CDVCommandStatus.ok.rawValue)
         XCTAssertTrue(plugin.authSystem is SafariAppOAuthSessionProvider)
     }
 
@@ -145,7 +144,6 @@ class OAuthPluginTests: XCTestCase {
         let cmd = CDVInvokedUrlCommand(arguments:["https://example.com"], callbackId:"", className:"CDVOAuthPlugin", methodName:"startOAuth")
         plugin.startOAuth(cmd!)
 
-        XCTAssertEqual(cmdDlg.lastResult.status as! UInt, CDVCommandStatus.ok.rawValue)
         XCTAssertTrue(plugin.authSystem is SFSafariViewControllerOAuthSessionProvider)
     }
 
@@ -160,7 +158,6 @@ class OAuthPluginTests: XCTestCase {
         let cmd = CDVInvokedUrlCommand(arguments:["https://example.com"], callbackId:"", className:"CDVOAuthPlugin", methodName:"startOAuth")
         plugin.startOAuth(cmd!)
 
-        XCTAssertEqual(cmdDlg.lastResult.status as! UInt, CDVCommandStatus.ok.rawValue)
         XCTAssertTrue(plugin.authSystem is SFAuthenticationSessionOAuthSessionProvider)
     }
 
@@ -175,7 +172,6 @@ class OAuthPluginTests: XCTestCase {
         let cmd = CDVInvokedUrlCommand(arguments:["https://example.com"], callbackId:"", className:"CDVOAuthPlugin", methodName:"startOAuth")
         plugin.startOAuth(cmd!)
 
-        XCTAssertEqual(cmdDlg.lastResult.status as! UInt, CDVCommandStatus.ok.rawValue)
         XCTAssertTrue(plugin.authSystem is ASWebAuthenticationSessionOAuthSessionProvider)
     }
 }

--- a/tests/ios/UITests/UITests.swift
+++ b/tests/ios/UITests/UITests.swift
@@ -63,6 +63,41 @@ class OAuthPluginUITests: XCTestCase {
         XCTAssert(loggedIn.exists)
     }
 
+    func testCancelledFlow() throws {
+        app.launch()
+        app.tap()
+
+        // Wait for the landing page to load
+        let landingPage = app.staticTexts["WELCOME!"]
+        _ = landingPage.waitForExistence(timeout: 5)
+
+        // Tap the button, Kronk!
+        let button = app.webViews.buttons["Sign in with OAuth"]
+        XCTAssert(button.exists)
+        XCTAssert(button.isHittable)
+        button.tap()
+
+        if #available(iOS 11.0, *) {
+            let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+            let continueBtn = springboard.buttons["Continue"]
+            if continueBtn.waitForExistence(timeout: 10) {
+                continueBtn.tap()
+            }
+        }
+
+        // Tap the cancel button
+        let oauthButton = app.buttons["Cancel"]
+        _ = oauthButton.waitForExistence(timeout: 25)
+        XCTAssert(oauthButton.exists)
+        XCTAssert(oauthButton.isHittable)
+        oauthButton.tap()
+
+        // Verify the app received the OAuth token and considers us logged in
+        let loggedIn = app.staticTexts["LOGIN CANCELLED!"]
+        _ = loggedIn.waitForExistence(timeout: 45)
+        XCTAssert(loggedIn.exists)
+    }
+
     private func runAuthenticationSessionFlow() {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         let continueBtn = springboard.buttons["Continue"]

--- a/www/oauth.js
+++ b/www/oauth.js
@@ -21,7 +21,23 @@ var noop = function() { };
 
 module.exports = function(url, name, features) {
   if (name && name.match && name.match(/^oauth:/)) {
-    cordova.exec(noop, noop, 'OAuth', 'startOAuth', [url]);
+    var wnd = null;
+    if (window.EventTarget) {
+      wnd = new EventTarget();
+    }
+
+    function success() {
+      if (wnd) {
+        if (wnd.onclose) {
+          wnd.onclose();
+        }
+        wnd.dispatchEvent(new Event('close'));
+      }
+    }
+
+    cordova.exec(success, noop, 'OAuth', 'startOAuth', [url]);
+
+    return wnd;
   } else {
     var originalWindowOpen = modulemapper.getOriginalSymbol(window, 'open');
     return originalWindowOpen.apply(window, arguments);


### PR DESCRIPTION
Ended up with a slightly different approach to close/cancel events where the `close` event on the OAuth window will always fire, and the application can use that detect if a login has happened or not. This is more consistent with existing web behaviour around `window.open`.

Closes #20.
Closes #31.
Closes #33.
Closes #37.